### PR TITLE
build(all): prevent concurrent workflow on same pr and branch

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,6 +8,10 @@ on:
     branches:
       - "main"
 
+concurrency:
+  group: linter:${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint_and_format:
     runs-on: ${{ matrix.os }}
@@ -36,5 +40,6 @@ jobs:
           black --check .
 
       - name: Run Flake8
+        if: ${{ always() }}
         run: |
           flake8

--- a/.github/workflows/test_core.yaml
+++ b/.github/workflows/test_core.yaml
@@ -15,6 +15,9 @@ on:
 
     branches:
       - "main"
+  concurrency:
+    group: test_core:${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
 
 jobs:
   pytest_and_coverage_core:
@@ -36,7 +39,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -e src/core
-      
+
       - name: Run Mypy
         run: |
           mypy ./src/core/openthaigpt_pretraining

--- a/.github/workflows/test_data.yaml
+++ b/.github/workflows/test_data.yaml
@@ -15,6 +15,9 @@ on:
 
     branches:
       - "main"
+  concurrency:
+    group: test_data:${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
 
 jobs:
   pytest_and_coverage_data:

--- a/.github/workflows/test_evaluation.yaml
+++ b/.github/workflows/test_evaluation.yaml
@@ -15,6 +15,9 @@ on:
 
     branches:
       - "main"
+  concurrency:
+    group: test_evaluation:${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
 
 jobs:
   pytest_and_coverage_evaluation:

--- a/.github/workflows/test_model.yaml
+++ b/.github/workflows/test_model.yaml
@@ -15,6 +15,9 @@ on:
 
     branches:
       - "main"
+  concurrency:
+    group: test_model:${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
 
 jobs:
   pytest_and_coverage_model:


### PR DESCRIPTION
## Why this PR
We have many redundant workflow when push multiple commits on the same PR

## Changes
- Action will check for previous running workflow on the same PR/Branch and programmatically steop them, leaving only the latest workflow running
<img width="552" alt="image" src="https://github.com/OpenThaiGPT/openthaigpt-pretraining/assets/12471844/f7db6491-d7f4-4be7-b3b7-22f0afc2ef0e">


## Related Issues
None

## Checklist
- [x] PR should be in the [Naming convention](../../docs/PR_NAMING.md)
- [x] Assign yourself in to Assigneees
- [x] Tag related issues
- [x] Constants name should be ALL_CAPITAL, function name should be snake_case, and class name should be CamelCase
- [x] complex function/algorithm should have [Docstring](https://peps.python.org/pep-0257/)
- [x] 1 PR should not have more than 200 lines changes (Exception for test files). If more than that please open multiple PRs
- [x] At least PR reviewer must come from the task's team (model, eval, data)
