### PR TITLE
feat(model): add gradient checkpointing to GPTJ and Llama

### DIFF
--- a/src/model/openthaigpt_pretraining_model/lightning/utils.py
+++ b/src/model/openthaigpt_pretraining_model/lightning/utils.py
@@ -13,8 +13,8 @@ from typing import List, Union
 from transformers import (
     AutoTokenizer,
     LlamaTokenizer,
-    LlamaConfig,
-    LlamaForCausalLM,
+    # LlamaConfig,
+    # LlamaForCausalLM,
 )
 from .constants import (
     DATASET_NAME,

--- a/src/model/openthaigpt_pretraining_model/lightning/utils.py
+++ b/src/model/openthaigpt_pretraining_model/lightning/utils.py
@@ -13,8 +13,6 @@ from typing import List, Union
 from transformers import (
     AutoTokenizer,
     LlamaTokenizer,
-    # LlamaConfig,
-    # LlamaForCausalLM,
 )
 from .constants import (
     DATASET_NAME,

--- a/src/model/openthaigpt_pretraining_model/lightning/utils.py
+++ b/src/model/openthaigpt_pretraining_model/lightning/utils.py
@@ -117,6 +117,15 @@ class Trainer:
                 max_position_embeddings=context_length,
             )
             self.model = model = LlamaForCausalLM(cfg)
+            if checkpoint:
+                self.model.gradient_checkpointing_enable()
+
+            model_size = sum(t.numel() for t in model.parameters())
+            print(f"LLAMA size: {model_size/1000**2:.1f}M parameters")
+
+            model_size = sum(p.numel() for p in model.parameters() if p.requires_grad)
+            print(f"LLAMA size requires_grad: {model_size/1000**2:.1f}M parameters")
+
         elif model_name == "gptj":
             model_name = GPTJ_MODEL  # for tokenizer
             self.model = model = make_model_gptj(

--- a/src/model/openthaigpt_pretraining_model/lightning/utils.py
+++ b/src/model/openthaigpt_pretraining_model/lightning/utils.py
@@ -96,7 +96,7 @@ class Trainer:
         lr: float = 1e-4,
         vocab_size: int = 50400,
         xformers: bool = False,
-        checkpoint: bool = False,
+        checkpoint: int = 0,
     ):
         self.max_tokens = context_length
         self.step = 0

--- a/src/model/openthaigpt_pretraining_model/models/gptj/gptj_model_xformers.py
+++ b/src/model/openthaigpt_pretraining_model/models/gptj/gptj_model_xformers.py
@@ -3,8 +3,22 @@ import xformers.ops as xops
 from xformers.components.attention.core import scaled_query_key_softmax, bmm
 from transformers.models.gptj.modeling_gptj import (
     GPTJAttention,
+    GPTJPreTrainedModel,
+    get_device_map,
+    assert_device_map,
+    GPTJBlock,
+    logger,
 )
 from transformers import GPTJConfig, GPTJForCausalLM
+from torch import nn
+from torch.nn import CrossEntropyLoss
+
+# import torch.utils.checkpoint as checkpoint
+from typing import Optional, Tuple, Union
+from transformers.modeling_outputs import (
+    BaseModelOutputWithPast,
+    CausalLMOutputWithPast,
+)
 
 
 def _attn_xformers_cpu(
@@ -59,10 +73,527 @@ def _attn_xformers(
     return attn_output, None
 
 
+class GPTJModel(GPTJPreTrainedModel):
+    def __init__(self, config):
+        super().__init__(config)
+
+        self.embed_dim = config.n_embd
+        self.vocab_size = config.vocab_size
+        self.wte = nn.Embedding(config.vocab_size, self.embed_dim)
+        self.drop = nn.Dropout(config.embd_pdrop)
+        self.h = nn.ModuleList(
+            [GPTJBlockWithCheckpointing(config) for _ in range(config.n_layer)]
+        )
+        self.ln_f = nn.LayerNorm(self.embed_dim, eps=config.layer_norm_epsilon)
+
+        # Model parallel
+        self.model_parallel = False
+        self.device_map = None
+        self.gradient_checkpointing = False
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    def parallelize(self, device_map=None):
+        # Check validity of device_map
+        self.device_map = (
+            get_device_map(len(self.h), range(torch.cuda.device_count()))
+            if device_map is None
+            else device_map
+        )
+        assert_device_map(self.device_map, len(self.h))
+        self.model_parallel = True
+        self.first_device = (
+            "cpu"
+            if "cpu" in self.device_map.keys()
+            else "cuda:" + str(min(self.device_map.keys()))
+        )
+        self.last_device = "cuda:" + str(max(self.device_map.keys()))
+        self.wte = self.wte.to(self.first_device)
+        # Load onto devices
+        for k, v in self.device_map.items():
+            for block in v:
+                cuda_device = "cuda:" + str(k)
+                self.h[block] = self.h[block].to(cuda_device)
+        # ln_f to last
+        self.ln_f = self.ln_f.to(self.last_device)
+
+    def deparallelize(self):
+        self.model_parallel = False
+        self.device_map = None
+        self.first_device = "cpu"
+        self.last_device = "cpu"
+        self.wte = self.wte.to("cpu")
+        for index in range(len(self.h)):
+            self.h[index] = self.h[index].to("cpu")
+        self.ln_f = self.ln_f.to("cpu")
+        torch.cuda.empty_cache()
+
+    def get_input_embeddings(self):
+        return self.wte
+
+    def set_input_embeddings(self, new_embeddings):
+        self.wte = new_embeddings
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Tuple[Tuple[torch.Tensor]]] = None,
+        attention_mask: Optional[torch.FloatTensor] = None,
+        token_type_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        head_mask: Optional[torch.FloatTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+    ) -> Union[Tuple, BaseModelOutputWithPast]:
+        output_attentions = (
+            output_attentions
+            if output_attentions is not None
+            else self.config.output_attentions
+        )
+        output_hidden_states = (
+            output_hidden_states
+            if output_hidden_states is not None
+            else self.config.output_hidden_states
+        )
+        use_cache = use_cache if use_cache is not None else self.config.use_cache
+        return_dict = (
+            return_dict if return_dict is not None else self.config.use_return_dict
+        )
+
+        if input_ids is not None and inputs_embeds is not None:
+            raise ValueError(
+                "You cannot specify both input_ids and inputs_embeds at the same time"
+            )
+        elif input_ids is not None:
+            input_shape = input_ids.size()
+            input_ids = input_ids.view(-1, input_shape[-1])
+            batch_size = input_ids.shape[0]
+        elif inputs_embeds is not None:
+            input_shape = inputs_embeds.size()[:-1]
+            batch_size = inputs_embeds.shape[0]
+        else:
+            raise ValueError("You have to specify either input_ids or inputs_embeds")
+
+        device = input_ids.device if input_ids is not None else inputs_embeds.device
+
+        if token_type_ids is not None:
+            token_type_ids = token_type_ids.view(-1, input_shape[-1])
+
+        if position_ids is not None:
+            position_ids = position_ids.view(-1, input_shape[-1]).long()
+
+        if past_key_values is None:
+            past_length = 0
+            past_key_values = tuple([None] * len(self.h))
+        else:
+            past_length = past_key_values[0][0].size(-2)
+
+        if position_ids is None:
+            position_ids = torch.arange(
+                past_length,
+                input_shape[-1] + past_length,
+                dtype=torch.long,
+                device=device,
+            )
+            position_ids = position_ids.unsqueeze(0).view(-1, input_shape[-1])
+
+        # Attention mask.
+        if attention_mask is not None:
+            if batch_size <= 0:
+                raise ValueError("batch_size has to be defined and > 0")
+            attention_mask = attention_mask.view(batch_size, -1)
+            # We create a 3D attention mask from a 2D tensor mask.
+            # Sizes are [batch_size, 1, 1, to_seq_length]
+            # So we can broadcast to [batch_size, num_heads, from_seq_length, to_seq_length]
+            # this attention mask is more simple than the triangular masking of causal attention
+            # used in OpenAI GPT, we just need to prepare the broadcast dimension here.
+            attention_mask = attention_mask[:, None, None, :]
+
+            # Since attention_mask is 1.0 for positions we want to attend and 0.0 for
+            # masked positions, this operation will create a tensor which is 0.0 for
+            # positions we want to attend and the dtype's smallest value for masked positions.
+            # Since we are adding it to the raw scores before the softmax, this is
+            # effectively the same as removing these entirely.
+            attention_mask = attention_mask.to(dtype=self.dtype)  # fp16 compatibility
+            attention_mask = (1.0 - attention_mask) * torch.finfo(self.dtype).min
+
+        # Prepare head mask if needed
+        # 1.0 in head_mask indicate we keep the head
+        # attention_probs has shape bsz x num_attention_heads x N x N
+        # head_mask has shape n_layer x batch x num_attention_heads x N x N
+        head_mask = self.get_head_mask(head_mask, self.config.n_layer)
+
+        if inputs_embeds is None:
+            inputs_embeds = self.wte(input_ids)
+
+        hidden_states = inputs_embeds
+
+        if token_type_ids is not None:
+            token_type_embeds = self.wte(token_type_ids)
+            hidden_states = hidden_states + token_type_embeds
+
+        hidden_states = self.drop(hidden_states)
+
+        output_shape = input_shape + (hidden_states.size(-1),)
+
+        if self.gradient_checkpointing and self.training:
+            if use_cache:
+                logger.warning_once(
+                    "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`..."
+                )
+                use_cache = False
+
+        presents = () if use_cache else None
+        all_self_attentions = () if output_attentions else None
+        all_hidden_states = () if output_hidden_states else None
+        for i, (block, layer_past) in enumerate(zip(self.h, past_key_values)):
+            # Model parallel
+            if self.model_parallel:
+                torch.cuda.set_device(hidden_states.device)
+                # Ensure layer_past is on same device as hidden_states (might not be correct)
+                if layer_past is not None:
+                    layer_past = tuple(
+                        past_state.to(hidden_states.device) for past_state in layer_past
+                    )
+                # Ensure that attention_mask is always on the same device as hidden_states
+                if attention_mask is not None:
+                    attention_mask = attention_mask.to(hidden_states.device)
+                if isinstance(head_mask, torch.Tensor):
+                    head_mask = head_mask.to(hidden_states.device)
+            if output_hidden_states:
+                all_hidden_states = all_hidden_states + (hidden_states,)
+
+            # if self.gradient_checkpointing and self.training:
+
+            #     def create_custom_forward(module):
+            #         def custom_forward(*inputs):
+            #             # None for past_key_value
+            #             return module(*inputs, use_cache, output_attentions)
+
+            #         return custom_forward
+
+            #     outputs = torch.utils.checkpoint.checkpoint(
+            #         create_custom_forward(block),
+            #         hidden_states,
+            #         None,
+            #         attention_mask,
+            #         position_ids,
+            #         head_mask[i],
+            #     )
+            # else:
+            #     outputs = block(
+            #         hidden_states=hidden_states,
+            #         layer_past=layer_past,
+            #         attention_mask=attention_mask,
+            #         position_ids=position_ids,
+            #         head_mask=head_mask[i],
+            #         use_cache=use_cache,
+            #         output_attentions=output_attentions,
+            #     )
+            outputs = block(
+                hidden_states=hidden_states,
+                layer_past=layer_past,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                head_mask=head_mask[i],
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                gradient_checkpointing=self.gradient_checkpointing,
+            )
+
+            hidden_states = outputs[0]
+            if use_cache is True:
+                presents = presents + (outputs[1],)
+
+            if output_attentions:
+                all_self_attentions = all_self_attentions + (
+                    outputs[2 if use_cache else 1],
+                )
+
+            # Model Parallel: If it's the last layer for that device, put things on the next device
+            if self.model_parallel:
+                for k, v in self.device_map.items():
+                    if i == v[-1] and "cuda:" + str(k) != self.last_device:
+                        hidden_states = hidden_states.to("cuda:" + str(k + 1))
+
+        hidden_states = self.ln_f(hidden_states)
+
+        hidden_states = hidden_states.view(output_shape)
+        # Add last hidden state
+        if output_hidden_states:
+            all_hidden_states = all_hidden_states + (hidden_states,)
+
+        if not return_dict:
+            return tuple(
+                v
+                for v in [
+                    hidden_states,
+                    presents,
+                    all_hidden_states,
+                    all_self_attentions,
+                ]
+                if v is not None
+            )
+
+        return BaseModelOutputWithPast(
+            last_hidden_state=hidden_states,
+            past_key_values=presents,
+            hidden_states=all_hidden_states,
+            attentions=all_self_attentions,
+        )
+
+
+class GPTJBlockWithCheckpointing(GPTJBlock):
+    def forward(
+        self,
+        hidden_states: Optional[torch.FloatTensor],
+        layer_past: Optional[Tuple[torch.Tensor]] = None,
+        attention_mask: Optional[torch.FloatTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        head_mask: Optional[torch.FloatTensor] = None,
+        use_cache: Optional[bool] = False,
+        output_attentions: Optional[bool] = False,
+        gradient_checkpointing: Optional[bool] = False,
+    ) -> Union[
+        Tuple[torch.Tensor],
+        Optional[Tuple[torch.Tensor, Tuple[torch.FloatTensor, ...]]],
+    ]:
+        residual = hidden_states
+        hidden_states = self.ln_1(hidden_states)
+
+        # Attention
+        if gradient_checkpointing and self.training:
+
+            def create_custom_forward(module):
+                def custom_forward(*inputs):
+                    return module(
+                        *inputs,
+                        layer_past,
+                        attention_mask,
+                        position_ids,
+                        head_mask,
+                        use_cache,
+                        output_attentions,
+                    )
+
+                return custom_forward
+
+            attn_outputs = torch.utils.checkpoint.checkpoint(
+                create_custom_forward(self.attn),
+                hidden_states,
+                layer_past=layer_past,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                head_mask=head_mask,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+            )
+        else:
+            attn_outputs = self.attn(
+                hidden_states=hidden_states,
+                layer_past=layer_past,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                head_mask=head_mask,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+            )
+
+        attn_output = attn_outputs[0]  # output_attn: a, present, (attentions)
+        outputs = attn_outputs[1:]
+
+        feed_forward_hidden_states = self.mlp(hidden_states)
+        hidden_states = attn_output + feed_forward_hidden_states + residual
+
+        if use_cache:
+            outputs = (hidden_states,) + outputs
+        else:
+            outputs = (hidden_states,) + outputs[1:]
+
+        return outputs
+
+
+class GPTJModify(GPTJPreTrainedModel):
+    _keys_to_ignore_on_load_missing = [
+        r"h\.\d+\.attn\.masked_bias",
+        r"h\.\d+\.attn\.bias",
+    ]
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.transformer = GPTJModel(config)
+        self.lm_head = nn.Linear(config.n_embd, config.vocab_size)
+
+        # Model parallel
+        self.model_parallel = False
+        self.device_map = None
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    def parallelize(self, device_map=None):
+        self.device_map = (
+            get_device_map(len(self.transformer.h), range(torch.cuda.device_count()))
+            if device_map is None
+            else device_map
+        )
+        assert_device_map(self.device_map, len(self.transformer.h))
+        self.transformer.parallelize(self.device_map)
+        self.lm_head = self.lm_head.to(self.transformer.first_device)
+        self.model_parallel = True
+
+    def deparallelize(self):
+        self.transformer.deparallelize()
+        self.transformer = self.transformer.to("cpu")
+        self.lm_head = self.lm_head.to("cpu")
+        self.model_parallel = False
+        torch.cuda.empty_cache()
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, new_embeddings):
+        self.lm_head = new_embeddings
+
+    def prepare_inputs_for_generation(
+        self, input_ids, past_key_values=None, inputs_embeds=None, **kwargs
+    ):
+        token_type_ids = kwargs.get("token_type_ids", None)
+        # only last token for inputs_ids if past is defined in kwargs
+        if past_key_values:
+            input_ids = input_ids[:, -1].unsqueeze(-1)
+            if token_type_ids is not None:
+                token_type_ids = token_type_ids[:, -1].unsqueeze(-1)
+
+        attention_mask = kwargs.get("attention_mask", None)
+        position_ids = kwargs.get("position_ids", None)
+
+        if attention_mask is not None and position_ids is None:
+            # create position_ids on the fly for batch generation
+            position_ids = attention_mask.long().cumsum(-1) - 1
+            position_ids.masked_fill_(attention_mask == 0, 1)
+            if past_key_values:
+                position_ids = position_ids[:, -1].unsqueeze(-1)
+
+        # if `inputs_embeds` are passed, we only want to use them in the 1st generation step
+        if inputs_embeds is not None and past_key_values is None:
+            model_inputs = {"inputs_embeds": inputs_embeds}
+        else:
+            model_inputs = {"input_ids": input_ids}
+
+        model_inputs.update(
+            {
+                "past_key_values": past_key_values,
+                "use_cache": kwargs.get("use_cache"),
+                "position_ids": position_ids,
+                "attention_mask": attention_mask,
+                "token_type_ids": token_type_ids,
+            }
+        )
+
+        return model_inputs
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Tuple[Tuple[torch.Tensor]]] = None,
+        attention_mask: Optional[torch.FloatTensor] = None,
+        token_type_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        head_mask: Optional[torch.FloatTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        labels: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+    ) -> Union[Tuple, CausalLMOutputWithPast]:
+        r"""
+        labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
+            Labels for language modeling. Note that the labels **are shifted** inside the model, i.e. you can set
+            `labels = input_ids` Indices are selected in `[-100, 0, ..., config.vocab_size]` All labels set to `-100`
+            are ignored (masked), the loss is only computed for labels in `[0, ..., config.vocab_size]`
+        """
+        return_dict = (
+            return_dict if return_dict is not None else self.config.use_return_dict
+        )
+
+        transformer_outputs = self.transformer(
+            input_ids,
+            past_key_values=past_key_values,
+            attention_mask=attention_mask,
+            token_type_ids=token_type_ids,
+            position_ids=position_ids,
+            head_mask=head_mask,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+        )
+        hidden_states = transformer_outputs[0]
+
+        # Set device for model parallelism
+        if self.model_parallel:
+            torch.cuda.set_device(self.transformer.first_device)
+            hidden_states = hidden_states.to(self.lm_head.weight.device)
+
+        # make sure sampling in fp16 works correctly and
+        # compute loss in fp32 to match with mesh-tf version
+        # https://github.com/EleutherAI/gpt-neo/blob/89ce74164da2fb16179106f54e2269b5da8db333/models/gpt2/gpt2.py#L179
+        lm_logits = self.lm_head(hidden_states).to(torch.float32)
+
+        loss = None
+        if labels is not None:
+            # Shift so that tokens < n predict n
+            shift_logits = lm_logits[..., :-1, :].contiguous()
+            shift_labels = labels[..., 1:].contiguous()
+            # Flatten the tokens
+            loss_fct = CrossEntropyLoss()
+            loss = loss_fct(
+                shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1)
+            )
+
+            loss = loss.to(hidden_states.dtype)
+
+        if not return_dict:
+            output = (lm_logits,) + transformer_outputs[1:]
+            return ((loss,) + output) if loss is not None else output
+
+        return CausalLMOutputWithPast(
+            loss=loss,
+            logits=lm_logits,
+            past_key_values=transformer_outputs.past_key_values,
+            hidden_states=transformer_outputs.hidden_states,
+            attentions=transformer_outputs.attentions,
+        )
+
+    @staticmethod
+    def _reorder_cache(
+        past_key_values: Tuple[Tuple[torch.Tensor]], beam_idx: torch.Tensor
+    ) -> Tuple[Tuple[torch.Tensor]]:
+        """
+        This function is used to re-order the `past_key_values` cache if [`~PretrainedModel.beam_search`] or
+        [`~PretrainedModel.beam_sample`] is called. This is required to match `past_key_values` with the correct
+        beam_idx at every generation step.
+        """
+        return tuple(
+            tuple(
+                past_state.index_select(0, beam_idx.to(past_state.device))
+                for past_state in layer_past
+            )
+            for layer_past in past_key_values
+        )
+
+
 def make_model_gptj(
     vocab_size, context_length, use_xformers, use_checkpointing, device: str = "cuda"
 ):
-    config = GPTJConfig(
+    cfg = GPTJConfig(
         vocab_size=vocab_size,
         n_positions=context_length,
         n_embd=1536,
@@ -81,7 +612,11 @@ def make_model_gptj(
         eos_token_id=50256,
         tie_word_embeddings=False,
     )
-    model = GPTJForCausalLM(config)
+    if use_checkpointing == 2:
+        model = GPTJModify(cfg)
+        print("use gradient checkpointing only attentions")
+    else:
+        model = GPTJForCausalLM(cfg)
 
     if use_xformers:
         print("Use xFormers")
@@ -92,9 +627,10 @@ def make_model_gptj(
     else:
         print("Use original")
 
-    # https://www.kaggle.com/code/vad13irt/optimization-approaches-for-transformers
     if use_checkpointing:
         model.gradient_checkpointing_enable()
+        if use_checkpointing == 1:
+            print("use gradient checkpointing")
 
     model_size = sum(t.numel() for t in model.parameters())
     print(f"GPTJ size: {model_size/1000**2:.1f}M parameters")

--- a/src/model/openthaigpt_pretraining_model/models/gptj/gptj_model_xformers.py
+++ b/src/model/openthaigpt_pretraining_model/models/gptj/gptj_model_xformers.py
@@ -13,7 +13,6 @@ from transformers import GPTJConfig, GPTJForCausalLM
 from torch import nn
 from torch.nn import CrossEntropyLoss
 
-# import torch.utils.checkpoint as checkpoint
 from typing import Optional, Tuple, Union
 from transformers.modeling_outputs import (
     BaseModelOutputWithPast,
@@ -266,34 +265,6 @@ class GPTJModel(GPTJPreTrainedModel):
                     head_mask = head_mask.to(hidden_states.device)  # type: ignore
             if output_hidden_states:
                 all_hidden_states = all_hidden_states + (hidden_states,)  # type: ignore
-
-            # if self.gradient_checkpointing and self.training:
-
-            #     def create_custom_forward(module):
-            #         def custom_forward(*inputs):
-            #             # None for past_key_value
-            #             return module(*inputs, use_cache, output_attentions)
-
-            #         return custom_forward
-
-            #     outputs = torch.utils.checkpoint.checkpoint(
-            #         create_custom_forward(block),
-            #         hidden_states,
-            #         None,
-            #         attention_mask,
-            #         position_ids,
-            #         head_mask[i],
-            #     )
-            # else:
-            #     outputs = block(
-            #         hidden_states=hidden_states,
-            #         layer_past=layer_past,
-            #         attention_mask=attention_mask,
-            #         position_ids=position_ids,
-            #         head_mask=head_mask[i],
-            #         use_cache=use_cache,
-            #         output_attentions=output_attentions,
-            #     )
             outputs = block(
                 hidden_states=hidden_states,
                 layer_past=layer_past,

--- a/src/model/openthaigpt_pretraining_model/models/llama_hf/model.py
+++ b/src/model/openthaigpt_pretraining_model/models/llama_hf/model.py
@@ -305,7 +305,7 @@ class LlamaDecoderLayerWithCheckpointing(LlamaDecoderLayer):
         return outputs
 
 
-class LlamaForModify(LlamaPreTrainedModel):
+class LlamaModify(LlamaPreTrainedModel):
     def __init__(self, config):
         super().__init__(config)
         self.model = LlamaModel(config)
@@ -484,7 +484,7 @@ def make_model_llama(vocab_size, context_length, use_checkpointing):
         max_position_embeddings=context_length,
     )
     if use_checkpointing == 2:
-        model = LlamaForModify(cfg)
+        model = LlamaModify(cfg)
         print("use gradient checkpointing only attentions")
     else:
         model = LlamaForCausalLM(cfg)

--- a/src/model/openthaigpt_pretraining_model/models/llama_hf/model.py
+++ b/src/model/openthaigpt_pretraining_model/models/llama_hf/model.py
@@ -485,10 +485,13 @@ def make_model_llama(vocab_size, context_length, use_checkpointing):
     )
     if use_checkpointing == 2:
         model = LlamaForModify(cfg)
+        print("use gradient checkpointing only attentions")
     else:
         model = LlamaForCausalLM(cfg)
     if use_checkpointing:
         model.gradient_checkpointing_enable()
+        if use_checkpointing == 1:
+            print("use gradient checkpointing")
 
     model_size = sum(t.numel() for t in model.parameters())
     print(f"LLAMA size: {model_size/1000**2:.1f}M parameters")

--- a/src/model/openthaigpt_pretraining_model/models/llama_hf/model.py
+++ b/src/model/openthaigpt_pretraining_model/models/llama_hf/model.py
@@ -1,0 +1,504 @@
+from transformers import (
+    # LlamaModel,
+    LlamaConfig,
+    # LlamaForCausalLM,
+    _make_causal_mask,
+    _expand_mask,
+    logger,
+)
+from transformers.models.llama.modeling_llama import (
+    LlamaPreTrainedModel,
+    LlamaDecoderLayer,
+    LlamaRMSNorm,
+)
+import torch
+from torch import nn
+from torch.nn import CrossEntropyLoss
+
+# import torch.utils.checkpoint as checkpoint
+from typing import Optional, Tuple, List, Union
+from transformers.modeling_outputs import (
+    BaseModelOutputWithPast,
+    CausalLMOutputWithPast,
+)
+
+
+class LlamaModel(LlamaPreTrainedModel):
+    """
+    Transformer decoder consisting of *config.num_hidden_layers* layers. Each layer is a [`LlamaDecoderLayer`]
+
+    Args:
+        config: LlamaConfig
+    """
+
+    def __init__(self, config: LlamaConfig):
+        super().__init__(config)
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+
+        self.embed_tokens = nn.Embedding(
+            config.vocab_size, config.hidden_size, self.padding_idx
+        )
+        self.layers = nn.ModuleList(
+            [
+                LlamaDecoderLayerWithCheckpointing(config)
+                for _ in range(config.num_hidden_layers)
+            ]
+        )
+        self.norm = LlamaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+        self.gradient_checkpointing = False
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.embed_tokens = value
+
+    # Copied from transformers.models.bart.modeling_bart.BartDecoder._prepare_decoder_attention_mask
+    def _prepare_decoder_attention_mask(
+        self, attention_mask, input_shape, inputs_embeds, past_key_values_length
+    ):
+        # create causal mask
+        # [bsz, seq_len] -> [bsz, 1, tgt_seq_len, src_seq_len]
+        combined_attention_mask = None
+        if input_shape[-1] > 1:
+            combined_attention_mask = _make_causal_mask(
+                input_shape,
+                inputs_embeds.dtype,
+                device=inputs_embeds.device,
+                past_key_values_length=past_key_values_length,
+            )
+
+        if attention_mask is not None:
+            # [bsz, seq_len] -> [bsz, 1, tgt_seq_len, src_seq_len]
+            expanded_attn_mask = _expand_mask(
+                attention_mask, inputs_embeds.dtype, tgt_len=input_shape[-1]
+            ).to(inputs_embeds.device)
+            combined_attention_mask = (
+                expanded_attn_mask
+                if combined_attention_mask is None
+                else expanded_attn_mask + combined_attention_mask
+            )
+
+        return combined_attention_mask
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[List[torch.FloatTensor]] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+    ) -> Union[Tuple, BaseModelOutputWithPast]:
+        output_attentions = (
+            output_attentions
+            if output_attentions is not None
+            else self.config.output_attentions
+        )
+        output_hidden_states = (
+            output_hidden_states
+            if output_hidden_states is not None
+            else self.config.output_hidden_states
+        )
+        use_cache = use_cache if use_cache is not None else self.config.use_cache
+
+        return_dict = (
+            return_dict if return_dict is not None else self.config.use_return_dict
+        )
+
+        # retrieve input_ids and inputs_embeds
+        if input_ids is not None and inputs_embeds is not None:
+            raise ValueError(
+                "You cannot specify both decoder_input_ids and decoder_inputs_embeds at the same time"
+            )
+        elif input_ids is not None:
+            batch_size, seq_length = input_ids.shape
+        elif inputs_embeds is not None:
+            batch_size, seq_length, _ = inputs_embeds.shape
+        else:
+            raise ValueError(
+                "You have to specify either decoder_input_ids or decoder_inputs_embeds"
+            )
+
+        seq_length_with_past = seq_length
+        past_key_values_length = 0
+
+        if past_key_values is not None:
+            past_key_values_length = past_key_values[0][0].shape[2]
+            seq_length_with_past = seq_length_with_past + past_key_values_length
+
+        if position_ids is None:
+            device = input_ids.device if input_ids is not None else inputs_embeds.device
+            position_ids = torch.arange(
+                past_key_values_length,
+                seq_length + past_key_values_length,
+                dtype=torch.long,
+                device=device,
+            )
+            position_ids = position_ids.unsqueeze(0).view(-1, seq_length)
+        else:
+            position_ids = position_ids.view(-1, seq_length).long()
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+        # embed positions
+        if attention_mask is None:
+            attention_mask = torch.ones(
+                (batch_size, seq_length_with_past),
+                dtype=torch.bool,
+                device=inputs_embeds.device,
+            )
+        attention_mask = self._prepare_decoder_attention_mask(
+            attention_mask,
+            (batch_size, seq_length),
+            inputs_embeds,
+            past_key_values_length,
+        )
+
+        hidden_states = inputs_embeds
+
+        if self.gradient_checkpointing and self.training:
+            if use_cache:
+                logger.warning_once(
+                    "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`..."
+                )
+                use_cache = False
+
+        # decoder layers
+        all_hidden_states = () if output_hidden_states else None
+        all_self_attns = () if output_attentions else None
+        next_decoder_cache = () if use_cache else None
+
+        for idx, decoder_layer in enumerate(self.layers):
+            if output_hidden_states:
+                all_hidden_states += (hidden_states,)
+
+            past_key_value = (
+                past_key_values[idx] if past_key_values is not None else None
+            )
+
+            if self.gradient_checkpointing and self.training:
+
+                def create_custom_forward(module):
+                    def custom_forward(*inputs):
+                        # None for past_key_value
+                        return module(*inputs, output_attentions, None)
+
+                    return custom_forward
+
+                layer_outputs = torch.utils.checkpoint.checkpoint(
+                    create_custom_forward(decoder_layer),
+                    hidden_states,
+                    attention_mask,
+                    position_ids,
+                    None,
+                )
+            else:
+                layer_outputs = decoder_layer(
+                    hidden_states,
+                    attention_mask=attention_mask,
+                    position_ids=position_ids,
+                    past_key_value=past_key_value,
+                    output_attentions=output_attentions,
+                    use_cache=use_cache,
+                )
+
+            hidden_states = layer_outputs[0]
+
+            if use_cache:
+                next_decoder_cache += (layer_outputs[2 if output_attentions else 1],)
+
+            if output_attentions:
+                all_self_attns += (layer_outputs[1],)
+
+        hidden_states = self.norm(hidden_states)
+
+        # add hidden states from the last decoder layer
+        if output_hidden_states:
+            all_hidden_states += (hidden_states,)
+
+        next_cache = next_decoder_cache if use_cache else None
+        if not return_dict:
+            return tuple(
+                v
+                for v in [hidden_states, next_cache, all_hidden_states, all_self_attns]
+                if v is not None
+            )
+        return BaseModelOutputWithPast(
+            last_hidden_state=hidden_states,
+            past_key_values=next_cache,
+            hidden_states=all_hidden_states,
+            attentions=all_self_attns,
+        )
+
+
+class LlamaForCausalLM(LlamaPreTrainedModel):
+    def __init__(self, config):
+        super().__init__(config)
+        self.model = LlamaModel(config)
+
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.model.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.model.embed_tokens = value
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, new_embeddings):
+        self.lm_head = new_embeddings
+
+    def set_decoder(self, decoder):
+        self.model = decoder
+
+    def get_decoder(self):
+        return self.model
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[List[torch.FloatTensor]] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        labels: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+    ) -> Union[Tuple, CausalLMOutputWithPast]:
+        r"""
+        Args:
+            labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
+                Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
+                config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
+                (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
+
+        Returns:
+
+        Example:
+
+        ```python
+        >>> from transformers import AutoTokenizer, LlamaForCausalLM
+
+        >>> model = LlamaForCausalLM.from_pretrained(PATH_TO_CONVERTED_WEIGHTS)
+        >>> tokenizer = AutoTokenizer.from_pretrained(PATH_TO_CONVERTED_TOKENIZER)
+
+        >>> prompt = "Hey, are you consciours? Can you talk to me?"
+        >>> inputs = tokenizer(prompt, return_tensors="pt")
+
+        >>> # Generate
+        >>> generate_ids = model.generate(inputs.input_ids, max_length=30)
+        >>> tokenizer.batch_decode(generate_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False)[0]
+        "Hey, are you consciours? Can you talk to me?\nI'm not consciours, but I can talk to you."
+        ```"""
+
+        output_attentions = (
+            output_attentions
+            if output_attentions is not None
+            else self.config.output_attentions
+        )
+        output_hidden_states = (
+            output_hidden_states
+            if output_hidden_states is not None
+            else self.config.output_hidden_states
+        )
+        return_dict = (
+            return_dict if return_dict is not None else self.config.use_return_dict
+        )
+
+        # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+        )
+
+        hidden_states = outputs[0]
+        logits = self.lm_head(hidden_states)
+
+        loss = None
+        if labels is not None:
+            # Shift so that tokens < n predict n
+            shift_logits = logits[..., :-1, :].contiguous()
+            shift_labels = labels[..., 1:].contiguous()
+            # Flatten the tokens
+            loss_fct = CrossEntropyLoss()
+            shift_logits = shift_logits.view(-1, self.config.vocab_size)
+            shift_labels = shift_labels.view(-1)
+            # Enable model parallelism
+            shift_labels = shift_labels.to(shift_logits.device)
+            loss = loss_fct(shift_logits, shift_labels)
+
+        if not return_dict:
+            output = (logits,) + outputs[1:]
+            return (loss,) + output if loss is not None else output
+
+        return CausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )
+
+    def prepare_inputs_for_generation(
+        self,
+        input_ids,
+        past_key_values=None,
+        attention_mask=None,
+        inputs_embeds=None,
+        **kwargs,
+    ):
+        if past_key_values:
+            input_ids = input_ids[:, -1:]
+
+        position_ids = kwargs.get("position_ids", None)
+        if attention_mask is not None and position_ids is None:
+            # create position_ids on the fly for batch generation
+            position_ids = attention_mask.long().cumsum(-1) - 1
+            position_ids.masked_fill_(attention_mask == 0, 1)
+            if past_key_values:
+                position_ids = position_ids[:, -1].unsqueeze(-1)
+
+        # if `inputs_embeds` are passed, we only want to use them in the 1st generation step
+        if inputs_embeds is not None and past_key_values is None:
+            model_inputs = {"inputs_embeds": inputs_embeds}
+        else:
+            model_inputs = {"input_ids": input_ids}
+
+        model_inputs.update(
+            {
+                "position_ids": position_ids,
+                "past_key_values": past_key_values,
+                "use_cache": kwargs.get("use_cache"),
+                "attention_mask": attention_mask,
+            }
+        )
+        return model_inputs
+
+    @staticmethod
+    def _reorder_cache(past_key_values, beam_idx):
+        reordered_past = ()
+        for layer_past in past_key_values:
+            reordered_past += (
+                tuple(
+                    past_state.index_select(0, beam_idx) for past_state in layer_past
+                ),
+            )
+        return reordered_past
+
+
+class LlamaDecoderLayerWithCheckpointing(LlamaDecoderLayer):
+    def __init__(self, config: LlamaConfig):
+        super().__init__(config)
+
+        self.gradient_checkpointing = config.gradient_checkpointing
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_value: Optional[Tuple[torch.Tensor]] = None,
+        output_attentions: Optional[bool] = False,
+        use_cache: Optional[bool] = False,
+    ) -> Tuple[
+        torch.FloatTensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]
+    ]:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+
+        # Self Attention
+        if self.gradient_checkpointing and self.training:
+
+            def create_custom_forward(module):
+                def custom_forward(*inputs):
+                    return module(
+                        *inputs,
+                        output_attentions=output_attentions,
+                        use_cache=use_cache,
+                    )
+
+                return custom_forward
+
+            (
+                hidden_states,
+                self_attn_weights,
+                present_key_value,
+            ) = torch.utils.checkpoint.checkpoint(
+                create_custom_forward(self.self_attn),
+                hidden_states,
+                attention_mask,
+                position_ids,
+                past_key_value,
+            )
+        else:
+            hidden_states, self_attn_weights, present_key_value = self.self_attn(
+                hidden_states=hidden_states,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_value=past_key_value,
+                output_attentions=output_attentions,
+                use_cache=use_cache,
+            )
+
+        hidden_states = residual + hidden_states
+
+        # Fully Connected
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+
+        outputs = (hidden_states,)
+
+        if output_attentions:
+            outputs += (self_attn_weights,)
+
+        if use_cache:
+            outputs += (present_key_value,)
+
+        return outputs
+
+
+def make_model_llama(
+    vocab_size, context_length, use_checkpointing, device: str = "cuda"
+):
+    cfg = LlamaConfig(
+        vocab_size=vocab_size,
+        hidden_size=1024,
+        num_hidden_layers=8,
+        num_attention_heads=8,
+        hidden_act="silu",
+        max_position_embeddings=context_length,
+        gradient_checkpointing=True,
+    )
+
+    model = LlamaForCausalLM(cfg)
+
+    model_size = sum(t.numel() for t in model.parameters())
+    print(f"LLAMA size: {model_size/1000**2:.1f}M parameters")
+    model_size = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    print(f"LLAMA size requires_grad: {model_size/1000**2:.1f}M parameters")
+
+    return model

--- a/src/model/openthaigpt_pretraining_model/models/llama_hf/model.py
+++ b/src/model/openthaigpt_pretraining_model/models/llama_hf/model.py
@@ -481,9 +481,7 @@ class LlamaDecoderLayerWithCheckpointing(LlamaDecoderLayer):
         return outputs
 
 
-def make_model_llama(
-    vocab_size, context_length, use_checkpointing, device: str = "cuda"
-):
+def make_model_llama(vocab_size, context_length, use_checkpointing):
     cfg = LlamaConfig(
         vocab_size=vocab_size,
         hidden_size=1024,
@@ -491,7 +489,7 @@ def make_model_llama(
         num_attention_heads=8,
         hidden_act="silu",
         max_position_embeddings=context_length,
-        gradient_checkpointing=True,
+        gradient_checkpointing=use_checkpointing,
     )
 
     model = LlamaForCausalLM(cfg)

--- a/src/model/openthaigpt_pretraining_model/models/llama_hf/model.py
+++ b/src/model/openthaigpt_pretraining_model/models/llama_hf/model.py
@@ -1,5 +1,4 @@
 from transformers import (
-    # LlamaModel,
     LlamaConfig,
     LlamaForCausalLM,
 )
@@ -12,7 +11,6 @@ from transformers.models.llama.modeling_llama import (
     logger,
 )
 
-# from transformers.modeling_utils import PreTrainedModel
 import torch
 from torch import nn
 from torch.nn import CrossEntropyLoss

--- a/src/model/openthaigpt_pretraining_model/models/llama_hf/model.py
+++ b/src/model/openthaigpt_pretraining_model/models/llama_hf/model.py
@@ -2,14 +2,14 @@ from transformers import (
     # LlamaModel,
     LlamaConfig,
     # LlamaForCausalLM,
-    _make_causal_mask,
-    _expand_mask,
-    logger,
 )
 from transformers.models.llama.modeling_llama import (
     LlamaPreTrainedModel,
     LlamaDecoderLayer,
     LlamaRMSNorm,
+    _make_causal_mask,
+    _expand_mask,
+    logger,
 )
 import torch
 from torch import nn

--- a/src/model/scripts/lighting_training/README.md
+++ b/src/model/scripts/lighting_training/README.md
@@ -17,4 +17,4 @@ argument that can custom
 - vocab size
 - lr
 - xformers
-- checkpoint
+- checkpoint: 0 | 1 (model) | 2 (self-attentions only)

--- a/src/model/scripts/lighting_training/train.py
+++ b/src/model/scripts/lighting_training/train.py
@@ -59,9 +59,9 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--checkpoint",
-        type=bool,
-        default=False,
-        help="gradient checkpoint only available for GPTJ",
+        type=int,
+        default=0,
+        help="0 | 1 (model) | 2 (self-attentions only)",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
## Why this PR
Implement Gradient Checkpointing for Lightning Fabric training pipeline

## Changes
- add Gradient Checkpointing option for GPTJ and LLama
### To test gradient checkpointing
```
!torchrun --standalone --nproc_per_node=1 src/model/scripts/lighting_training/train.py --model_name llama --vocab_size 32000 --checkpoint 1
```
- 1 is for model 
- 2 is for self attentions only
## Related Issues
Close #116 

## Checklist
- [x] PR should be in the [Naming convention](../../docs/PR_NAMING.md)
- [x] Assign yourself in to Assigneees
- [x] Tag related issues
- [x] Constants name should be ALL_CAPITAL, function name should be snake_case, and class name should be CamelCase
- [x] complex function/algorithm should have [Docstring](https://peps.python.org/pep-0257/)
- [x] 1 PR should not have more than 200 lines changes (Exception for test files). If more than that please open multiple PRs
- [x] At least PR reviewer must come from the task's team (model, eval, data)
