### PR TITLE
fix(model): fix bug don't found sentence in train tokenizer

### DIFF
--- a/src/model/openthaigpt_pretraining_model/tokenizers/spm_trainer.py
+++ b/src/model/openthaigpt_pretraining_model/tokenizers/spm_trainer.py
@@ -116,10 +116,6 @@ def train_tokenizer(
     text_processed_dataset = text_dataset.map(
         function=prepare_datasets,
         batched=True,
-        remove_columns=[
-            DOC_TEXT,
-            DOC_ID,
-        ],  # this is must b/c we will return different number of rows
     )
 
     spm.SentencePieceTrainer.train(


### PR DESCRIPTION
## Why this PR
fix bug don't found sentence in train tokenizer

## Changes
- don't remove column ```text``` and ```id``` in map function

## Related Issues
Close #

## Checklist
- [ ] PR should be in the [Naming convention](../../docs/PR_NAMING.md)
- [ ] Assign yourself in to Assigneees
- [ ] Tag related issues
- [ ] Constants name should be ALL_CAPITAL, function name should be snake_case, and class name should be CamelCase
- [ ] complex function/algorithm should have [Docstring](https://peps.python.org/pep-0257/)
- [ ] 1 PR should not have more than 200 lines changes (Exception for test files). If more than that please open multiple PRs
- [ ] At least PR reviewer must come from the task's team (model, eval, data)
