### PR TITLE
feat(model): load hf dataset from local in spm_trainer

### DIFF
--- a/src/model/openthaigpt_pretraining_model/tokenizers/spm_trainer.py
+++ b/src/model/openthaigpt_pretraining_model/tokenizers/spm_trainer.py
@@ -54,7 +54,7 @@ def train_tokenizer(
     load_dataset_path: str = "oscar",
     load_dataset_name: str = "unshuffled_deduplicated_th",
     load_dataset_local_path: Optional[str] = None,
-    load_dataset_data_type: str = "csv",
+    load_dataset_data_type: Optional[str] = None,
 ) -> None:
     """
     Train a SentencePiece tokenizer on a large text dataset.
@@ -103,15 +103,23 @@ def train_tokenizer(
 
     else:
         # Stream from local files
-        data_files = {
-            "train": [
-                f"{load_dataset_local_path}/{filename}"
-                for filename in os.listdir(load_dataset_local_path)
-            ]
-        }
-        text_dataset = load_dataset(
-            load_dataset_data_type, data_files=data_files, split="train", streaming=True
-        )
+        if load_dataset_data_type is None:
+            text_dataset = load_dataset(
+                load_dataset_local_path, split="train", streaming=True
+            )
+        else:
+            data_files = {
+                "train": [
+                    f"{load_dataset_local_path}/{filename}"
+                    for filename in os.listdir(load_dataset_local_path)
+                ]
+            }
+            text_dataset = load_dataset(
+                load_dataset_data_type,
+                data_files=data_files,
+                split="train",
+                streaming=True,
+            )
 
     text_processed_dataset = text_dataset.map(
         function=prepare_datasets,

--- a/src/model/scripts/spm_training/train.py
+++ b/src/model/scripts/spm_training/train.py
@@ -12,7 +12,9 @@ if __name__ == "__main__":
     )
     parser.add_argument("--data_path", type=str, help="path of datasets", required=True)
     parser.add_argument(
-        "--data_type", type=str, default="json", help="data type of dataset"
+        "--data_type",
+        default=None,
+        help="data type of dataset if None will be Huggingface format",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
## Why this PR
Spm trainer can load hf dataset in local

## Changes
- spm trainer will load dataset as hf format when data_type is None

## Related Issues
Close #

## Checklist
- [ ] PR should be in the [Naming convention](../../docs/PR_NAMING.md)
- [ ] Assign yourself in to Assigneees
- [ ] Tag related issues
- [ ] Constants name should be ALL_CAPITAL, function name should be snake_case, and class name should be CamelCase
- [ ] complex function/algorithm should have [Docstring](https://peps.python.org/pep-0257/)
- [ ] 1 PR should not have more than 200 lines changes (Exception for test files). If more than that please open multiple PRs
- [ ] At least PR reviewer must come from the task's team (model, eval, data)
