### PR TITLE
feat(model): add ```train_extremely_large_corpus``` option to ```spm_train```

### DIFF
--- a/src/model/openthaigpt_pretraining_model/tokenizers/spm_trainer.py
+++ b/src/model/openthaigpt_pretraining_model/tokenizers/spm_trainer.py
@@ -55,6 +55,7 @@ def train_tokenizer(
     load_dataset_name: str = "unshuffled_deduplicated_th",
     load_dataset_local_path: Optional[str] = None,
     load_dataset_data_type: str = "csv",
+    large_corpus: bool = False,
 ) -> None:
     """
     Train a SentencePiece tokenizer on a large text dataset.
@@ -126,4 +127,5 @@ def train_tokenizer(
         vocab_size=vocab_size,
         user_defined_symbols=USER_DEFINED_SYMBOLS,
         num_threads=num_proc,
+        train_extremely_large_corpus=large_corpus,
     )

--- a/src/model/scripts/spm_training/train.py
+++ b/src/model/scripts/spm_training/train.py
@@ -14,6 +14,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "--data_type", type=str, default="json", help="data type of dataset"
     )
+    parser.add_argument(
+        "--large_corpus", action="store_true", help="use large corpus in train"
+    )
 
     args = parser.parse_args()
 
@@ -22,4 +25,5 @@ if __name__ == "__main__":
         args.vocab_size,
         load_dataset_local_path=args.data_path,
         load_dataset_data_type=args.data_type,
+        large_corpus=args.large_corpus,
     )


### PR DESCRIPTION
## Why this PR
can use ```train_extremely_large_corpus``` for train tokenizer large corpus

## Changes
- add ```large_corpus``` argument to ```output_path``` for activate ```train_extremely_large_corpus```

## Related Issues
Close #

## Checklist
- [ ] PR should be in the [Naming convention](../../docs/PR_NAMING.md)
- [ ] Assign yourself in to Assigneees
- [ ] Tag related issues
- [ ] Constants name should be ALL_CAPITAL, function name should be snake_case, and class name should be CamelCase
- [ ] complex function/algorithm should have [Docstring](https://peps.python.org/pep-0257/)
- [ ] 1 PR should not have more than 200 lines changes (Exception for test files). If more than that please open multiple PRs
- [ ] At least PR reviewer must come from the task's team (model, eval, data)
