### PR TITLE
feat(model): don't need load merges file for merge tokenizer

### DIFF
--- a/src/model/scripts/gptj_thai_tokenizer/load_tokenizer.py
+++ b/src/model/scripts/gptj_thai_tokenizer/load_tokenizer.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
         "--tokenizer_path", type=str, required=True, help="path to save tokenizer"
     )
     parser.add_argument(
-        "--merge_file_path", type=str, required=True, help="path to save merge rule"
+        "--merge_file_path", default=None, help="path to save merge rule"
     )
 
     args = parser.parse_args()
@@ -23,8 +23,9 @@ if __name__ == "__main__":
     tokenizer = AutoTokenizer.from_pretrained(args.model_name)
     tokenizer.save_pretrained(args.tokenizer_path)
 
-    hf_hub_download(
-        repo_id=args.model_name,
-        filename="merges.txt",
-        local_dir=args.merge_file_path,
-    )
+    if args.merge_file_path is not None:
+        hf_hub_download(
+            repo_id=args.model_name,
+            filename="merges.txt",
+            local_dir=args.merge_file_path,
+        )

--- a/src/model/scripts/gptj_thai_tokenizer/merge_tokenizers.py
+++ b/src/model/scripts/gptj_thai_tokenizer/merge_tokenizers.py
@@ -15,14 +15,12 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--merge_file_1",
-        type=str,
-        required=True,
+        default=None,
         help="path to merge rule of tokenizer_1",
     )
     parser.add_argument(
         "--merge_file_2",
-        type=str,
-        required=True,
+        default=None,
         help="path to merge rule of tokenizer_2",
     )
     parser.add_argument(
@@ -31,9 +29,16 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    thai_tokenizer_repo = args.thai_tokenizer_repo
+    if args.merge_file_1 is None:
+        merge_file_1 = args.tokenizer_1_dir + "/merges.txt"
+    else:
+        merge_file_1 = args.merge_file_1
+    if args.merge_file_2 is None:
+        merge_file_2 = args.tokenizer_2_dir + "/merges.txt"
+    else:
+        merge_file_2 = args.merge_file_2
 
     tokenizer = merge(
-        args.tokenizer_1_dir, args.tokenizer_2_dir, args.merge_file_1, args.merge_file_2
+        args.tokenizer_1_dir, args.tokenizer_2_dir, merge_file_1, merge_file_2
     )
     tokenizer.save_pretrained(args.output_dir)


### PR DESCRIPTION
## Why this PR
```save_pretrained``` of tokenizer can save merges file to local path we don't need to specific load only merges file

## Changes
- don't need to load merges from ```load tokenizer```
- auto select merges file when merge tokenizer

## Related Issues
Close #

## Checklist
- [ ] PR should be in the [Naming convention](../../docs/PR_NAMING.md)
- [ ] Assign yourself in to Assigneees
- [ ] Tag related issues
- [ ] Constants name should be ALL_CAPITAL, function name should be snake_case, and class name should be CamelCase
- [ ] complex function/algorithm should have [Docstring](https://peps.python.org/pep-0257/)
- [ ] 1 PR should not have more than 200 lines changes (Exception for test files). If more than that please open multiple PRs
- [ ] At least PR reviewer must come from the task's team (model, eval, data)
