### PR TITLE
debug(model): convert AutoTokenizer to PreTrainedTokenizerFast

### DIFF
--- a/src/model/openthaigpt_pretraining_model/GPTJ_TH_tokenizer/merge.py
+++ b/src/model/openthaigpt_pretraining_model/GPTJ_TH_tokenizer/merge.py
@@ -1,4 +1,4 @@
-from transformers import AutoTokenizer, GPT2TokenizerFast
+from transformers import PreTrainedTokenizerFast, GPT2TokenizerFast
 import json
 import os
 from typing import Dict
@@ -6,8 +6,8 @@ from typing import Dict
 
 def merge(tokenizer_dir_1, tokenizer_dir_2, merge_file_1, merge_file_2):
     # load tokenizer
-    gptj_tokenizer = AutoTokenizer.from_pretrained(tokenizer_dir_1)
-    gpt2_tokenizer = AutoTokenizer.from_pretrained(tokenizer_dir_2)
+    gptj_tokenizer = PreTrainedTokenizerFast.from_pretrained(tokenizer_dir_1)
+    gpt2_tokenizer = PreTrainedTokenizerFast.from_pretrained(tokenizer_dir_2)
 
     # retrieve the vocabs
     gptj_vocab = gptj_tokenizer.get_vocab()


### PR DESCRIPTION
## Why this PR
```AutoTokenizer``` can't load from ```tokenizer.json``` then we wil use ```PreTrainedTokenizerFast``` instead.

## Changes
- change ```AutoTokenizer```  to ```PreTrainedTokenizerFast```

## Related Issues
Close #

## Checklist
- [ ] PR should be in the [Naming convention](../../docs/PR_NAMING.md)
- [ ] Assign yourself in to Assigneees
- [ ] Tag related issues
- [ ] Constants name should be ALL_CAPITAL, function name should be snake_case, and class name should be CamelCase
- [ ] complex function/algorithm should have [Docstring](https://peps.python.org/pep-0257/)
- [ ] 1 PR should not have more than 200 lines changes (Exception for test files). If more than that please open multiple PRs
- [ ] At least PR reviewer must come from the task's team (model, eval, data)
