### PR TITLE
debug(model): load_dataset to load_from_dist

### DIFF
--- a/src/model/openthaigpt_pretraining_model/tokenizers/spm_trainer.py
+++ b/src/model/openthaigpt_pretraining_model/tokenizers/spm_trainer.py
@@ -2,7 +2,7 @@ import os
 from typing import Optional, Union
 from tqdm import tqdm
 import sentencepiece as spm
-from datasets import load_dataset, Dataset
+from datasets import load_dataset, load_from_disk, Dataset
 
 # CONSTANTS
 PREPARE_DATASETS_KEY = "text_processed"
@@ -48,7 +48,7 @@ class DataSetColumnIterator:
 
 def load_local_dataset(data_type, local_path):
     if data_type is None:
-        text_dataset = load_dataset(local_path, split="train", streaming=True)
+        text_dataset = load_from_disk(local_path)["train"]
     else:
         data_files = {
             "train": [f"{local_path}/{filename}" for filename in os.listdir(local_path)]


### PR DESCRIPTION
## Why this PR
hf dataset can't local load from ```load_dataset``` we will use ```load_from_dist``` instead

## Changes
- change ```load_dataset``` to ```load_from_dist```

## Related Issues
Close #

## Checklist
- [ ] PR should be in the [Naming convention](../../docs/PR_NAMING.md)
- [ ] Assign yourself in to Assigneees
- [ ] Tag related issues
- [ ] Constants name should be ALL_CAPITAL, function name should be snake_case, and class name should be CamelCase
- [ ] complex function/algorithm should have [Docstring](https://peps.python.org/pep-0257/)
- [ ] 1 PR should not have more than 200 lines changes (Exception for test files). If more than that please open multiple PRs
- [ ] At least PR reviewer must come from the task's team (model, eval, data)
