### PR TITLE
feat(model): add spm and bpe mode in spm trainer

### DIFF
--- a/src/model/configuration_example/example_spm_training.yaml
+++ b/src/model/configuration_example/example_spm_training.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - spm: training_v1

--- a/src/model/configuration_example/spm/training_v1.yaml
+++ b/src/model/configuration_example/spm/training_v1.yaml
@@ -1,0 +1,9 @@
+output_path: 'tokenizer'
+vocab_size: 30000
+is_slurm: false
+load_dataset_path: oscar
+load_dataset_name: unshuffled_deduplicated_th
+load_dataset_local_path: None
+load_dataset_data_type: None
+large_corpus: false
+mode: spm # spm | bpe

--- a/src/model/configuration_example/spm_training.yaml
+++ b/src/model/configuration_example/spm_training.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - spm: training_v1

--- a/src/model/openthaigpt_pretraining_model/data_wrapper.py
+++ b/src/model/openthaigpt_pretraining_model/data_wrapper.py
@@ -51,7 +51,9 @@ def tokenize_function(tokenizer, max_tokens):
         # Iterate over each sublist and extend the result list with sublist elements
         for sublist in outputs[HF_TOKENIZER_INPUT_IDS_NAME]:
             result_list.extend(sublist)
-            result_list.append(0)  # Insert 0 between sublist elements
+            result_list.append(
+                tokenizer.eos_token_id
+            )  # Insert 0 between sublist elements
         # desired_dim_2 = 4  # Desired size along the second dimension
         padding_value = tokenizer.eos_token_id  # Number to use for padding
         input_tensor = torch.Tensor(result_list).long()

--- a/src/model/scripts/spm_training/train.py
+++ b/src/model/scripts/spm_training/train.py
@@ -1,5 +1,9 @@
 import argparse
-from openthaigpt_pretraining_model.tokenizers.spm_trainer import train_tokenizer
+from openthaigpt_pretraining_model.tokenizers.spm_trainer import (
+    train_tokenizer,
+    SPM_MODE,
+    BPE_MODE,
+)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -18,6 +22,9 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--large_corpus", action="store_true", help="use large corpus in train"
+    )
+    parser.add_argument(
+        "--mode", type=str, default=SPM_MODE, help=f"{SPM_MODE} | {BPE_MODE}"
     )
 
     args = parser.parse_args()

--- a/src/model/scripts/spm_training/train.py
+++ b/src/model/scripts/spm_training/train.py
@@ -35,4 +35,5 @@ if __name__ == "__main__":
         load_dataset_local_path=args.data_path,
         load_dataset_data_type=args.data_type,
         large_corpus=args.large_corpus,
+        mode=args.mode,
     )

--- a/src/model/scripts/spm_training/train.py
+++ b/src/model/scripts/spm_training/train.py
@@ -1,39 +1,30 @@
 import argparse
 from openthaigpt_pretraining_model.tokenizers.spm_trainer import (
     train_tokenizer,
-    SPM_MODE,
-    BPE_MODE,
 )
+from openthaigpt_pretraining_model.utils import load_hydra_config
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
-        "--output_path", type=str, help="path of tokenizer file", required=True
-    )
-    parser.add_argument(
-        "--vocab_size", type=int, default=50000, help="max vocab of tokenier"
-    )
-    parser.add_argument("--data_path", type=str, help="path of datasets", required=True)
-    parser.add_argument(
-        "--data_type",
-        default=None,
-        help="data type of dataset if None will be Huggingface format",
-    )
-    parser.add_argument(
-        "--large_corpus", action="store_true", help="use large corpus in train"
-    )
-    parser.add_argument(
-        "--mode", type=str, default=SPM_MODE, help=f"{SPM_MODE} | {BPE_MODE}"
+        "--configuration",
+        type=str,
+        default="../configuration_example/spm_training.yaml",
     )
 
     args = parser.parse_args()
 
+    config = load_hydra_config(args.configuration)
+
     train_tokenizer(
-        args.output_path,
-        args.vocab_size,
-        load_dataset_local_path=args.data_path,
-        load_dataset_data_type=args.data_type,
-        large_corpus=args.large_corpus,
-        mode=args.mode,
+        output_path=config.output_path,
+        vocab_size=config.vocab_size,
+        is_slurm=config.is_slurm,
+        load_dataset_path=config.load_dataset_path,
+        load_dataset_name=config.load_dataset_name,
+        load_dataset_local_path=config.load_dataset_local_path,
+        load_dataset_data_type=config.load_dataset_data_type,
+        large_corpus=config.large_corpus,
+        mode=config.mode,
     )


### PR DESCRIPTION
## Why this PR
Make ```spm_trainer``` can switch between spm and bpe mode for train sentencepiece tokenizer

## Changes
- ```spm_trainer``` can select mode for train
- add <unk> and <eos> token when train sentencepiece finish
- use ```eos_token_id``` separator sentence when tokenize sentence instead ```0```

## Related Issues
Close #

## Checklist
- [ ] PR should be in the [Naming convention](../../docs/PR_NAMING.md)
- [ ] Assign yourself in to Assigneees
- [ ] Tag related issues
- [ ] Constants name should be ALL_CAPITAL, function name should be snake_case, and class name should be CamelCase
- [ ] complex function/algorithm should have [Docstring](https://peps.python.org/pep-0257/)
- [ ] 1 PR should not have more than 200 lines changes (Exception for test files). If more than that please open multiple PRs
- [ ] At least PR reviewer must come from the task's team (model, eval, data)
