### PR TITLE
feat(model): add gradient checkpointing falcon

### DIFF
--- a/src/model/openthaigpt_pretraining_model/models/constants.py
+++ b/src/model/openthaigpt_pretraining_model/models/constants.py
@@ -1,5 +1,5 @@
 from transformers import AutoTokenizer, LlamaTokenizer, LlamaConfig, GPTJConfig
-from .falcon.model import RWForCausalLM
+from .falcon.model import RWForCausalLMwithCheckpointing
 from .falcon.configuration_RW import RWConfig
 from .llama.model import LLaMAArgs, LLaMA
 from .llama_hf.model import LlamaForCausalLMWithCheckpointing
@@ -11,7 +11,7 @@ TOKENIZERS = {
 }
 
 MODELS = {
-    "falcon": RWForCausalLM,  # type: ignore
+    "falcon": RWForCausalLMwithCheckpointing,  # type: ignore
     "llama_hf": LlamaForCausalLMWithCheckpointing,
     "gptj": GPTJForCausalLMWithCheckpointing,
     "llama": LLaMA,

--- a/src/model/openthaigpt_pretraining_model/models/gptj/gptj_model_xformers.py
+++ b/src/model/openthaigpt_pretraining_model/models/gptj/gptj_model_xformers.py
@@ -341,7 +341,7 @@ class GPTJForCausalLMWithCheckpointing(GPTJForCausalLM):
     def __init__(self, config):
         super().__init__(config)
         use_checkpointing = config.get("use_checkpointing", False)
-        checkpoint_only_attention = config.get("use_checkpointing", False)
+        checkpoint_only_attention = config.get("checkpoint_only_attention", False)
         if use_checkpointing and checkpoint_only_attention:
             self.transformer = GPTJModelWithCheckpointing(config)
             print("use model with gradient checkpointing only attention")


### PR DESCRIPTION
## Why this PR
falcon need gradient checkpointing

## Changes
- add gradient checkpointing falcon
- add DecoderLayerWithCheckpointing with have checkpoint only attention block and inherit back to RWForCausalLMwithCheckpointing (similar to gptj)
- test with bf16 and deepspeed stage2
- solve wrong config on gptj gradient checkpointing only head attention

## Related Issues
Close #

## Checklist
- [x] PR should be in the [Naming convention](../../docs/PR_NAMING.md)
- [x] Assign yourself in to Assigneees
- [x] Tag related issues
- [x] Constants name should be ALL_CAPITAL, function name should be snake_case, and class name should be CamelCase
- [x] complex function/algorithm should have [Docstring](https://peps.python.org/pep-0257/)
- [ ] 1 PR should not have more than 200 lines changes (Exception for test files). If more than that please open multiple PRs
- [x] At least PR reviewer must come from the task's team (model, eval, data)
